### PR TITLE
release/v0.2.0をmainブランチにマージ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "japanese-address-parser-nodejs"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-japanese-address-parser = { version = "0.2.0-rc.2", features = ["experimental"] }
+japanese-address-parser = { version = "0.2.0", features = ["experimental"] }
 napi = { version = "2.16.13", features = ["async"] }
 napi-derive = "2.16.12"
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # japanese-address-parser-nodejs
+
+[![npmjs](https://img.shields.io/npm/v/%40toriyama/japanese-address-parser-nodejs)](https://www.npmjs.com/package/@toriyama/japanese-address-parser-nodejs)
+[![install size](https://packagephobia.com/badge?p=@toriyama/japanese-address-parser-nodejs)](https://packagephobia.com/result?p=@toriyama/japanese-address-parser-nodejs)
+[![downloads](https://img.shields.io/npm/dm/@toriyama/japanese-address-parser-nodejs.svg)](https://npmcharts.com/compare/@toriyama/japanese-address-parser-nodejs?minimal=true)
+
 A Node.js binding for `japanese-address-parser` written in Rust.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,46 @@
 [![downloads](https://img.shields.io/npm/dm/@toriyama/japanese-address-parser-nodejs.svg)](https://npmcharts.com/compare/@toriyama/japanese-address-parser-nodejs?minimal=true)
 
 A Node.js binding for `japanese-address-parser` written in Rust.
+
+## Install
+
+```bash
+npm i @toriyama/japanese-address-parser-nodejs
+```
+
+## Usage
+
+### Construct parser
+
+```typescript
+import {Parser} from "@toriyama/japanese-address-parser-nodejs";
+
+const parser = new Parser();
+parser.parse("東京都中央区日本橋室町１丁目１").then(result => {
+    console.log(result.prefecture); // 東京都
+    console.log(result.city); // 中央区
+    console.log(result.town); // 日本橋室町一丁目
+    console.log(result.rest); // 1
+    console.log(result.metadata); // { depth: 3 }
+});
+```
+
+### Construct parser with options
+
+```typescript
+import {Parser, ParserOptions} from "@toriyama/japanese-address-parser-nodejs";
+
+const options: ParserOptions = {
+    dataSource: "ChimeiRuiju",
+    correctIncompleteCityNames: false,
+    verbose: false,
+}
+const parser = Parser.initWithOptions(options)
+parser.parse("東京都中央区日本橋室町１丁目１").then(result => {
+    console.log(result.prefecture); // 東京都
+    console.log(result.city); // 中央区
+    console.log(result.town); // 日本橋室町一丁目
+    console.log(result.rest); // 1
+    console.log(result.metadata); // { latitude: 35.68540495238095, longitude: 139.7749854761905, depth: 3 }
+});
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toriyama/japanese-address-parser-nodejs",
-  "version": "0.2.0-rc.3",
+  "version": "0.2.0",
   "description": "A Node.js binding for japanese-address-parser written in Rust.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
### 変更点
- `japanese-address-parser`のバージョンを`0.2.0`に変更
- `README.md`に情報を追加
  - related #5 