### PR TITLE
release/v0.2.7をmainブランチにマージ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "japanese-address-parser-nodejs"
-version = "0.2.4"
+version = "0.2.7"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-japanese-address-parser = { version = "0.2.4", features = ["experimental"] }
+japanese-address-parser = { version = "0.2.7", features = ["experimental"] }
 napi = { version = "2.16.13", features = ["async"] }
 napi-derive = "2.16.12"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toriyama/japanese-address-parser-nodejs",
-  "version": "0.2.4",
+  "version": "0.2.7",
   "description": "A Node.js binding for japanese-address-parser written in Rust.",
   "keywords": [
     "utility",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use napi_derive::napi;
 #[napi(js_name = "Parser")]
 pub struct JsParser {
     parser: Parser,
+    options: japanese_address_parser::experimental::parser::ParserOptions,
 }
 
 #[napi(object)]
@@ -35,28 +36,28 @@ impl JsParser {
     pub fn new() -> Self {
         JsParser {
             parser: Parser::default(),
+            options: Default::default(),
         }
     }
 
     #[napi(factory)]
     pub fn init_with_options(options: ParserOptions) -> Self {
         JsParser {
-            parser: Parser {
-                options: japanese_address_parser::experimental::parser::ParserOptions {
-                    data_source: match options.data_source.as_str() {
-                        "ChimeiRuiju" => DataSource::ChimeiRuiju,
-                        _ => DataSource::Geolonia,
-                    },
-                    correct_incomplete_city_names: options.correct_incomplete_city_names,
-                    verbose: options.verbose,
+            parser: Parser::default(),
+            options: japanese_address_parser::experimental::parser::ParserOptions {
+                data_source: match options.data_source.as_str() {
+                    "ChimeiRuiju" => DataSource::ChimeiRuiju,
+                    _ => DataSource::Geolonia,
                 },
+                correct_incomplete_city_names: options.correct_incomplete_city_names,
+                verbose: options.verbose,
             },
         }
     }
 
     #[napi]
     pub async fn parse(&self, input: String) -> napi::Result<ParsedAddress> {
-        let result = self.parser.parse(&input).await;
+        let result = self.parser.parse_with_options(&input, &self.options).await;
         Ok(ParsedAddress {
             prefecture: result.prefecture,
             city: result.city,


### PR DESCRIPTION
### 変更点
- `japanese-address-parser`のバージョンを0.2.4から0.2.7に変更