### PR TITLE
release/v0.3.0をmainブランチにマージ

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         runner: [ macos-latest, ubuntu-latest ]
-        node-version: [ '20', '22' ]
+        node-version: [ '20', '22', '24' ]
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -96,6 +96,4 @@ jobs:
           merge-multiple: true
       - run: ls -l dist
       - name: Publish
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           scope: '@toriyama'
       - name: Download all artifacts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "japanese-address-parser-nodejs"
-version = "0.2.7"
+version = "0.3.0"
 edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-japanese-address-parser = { version = "0.2.7", features = ["experimental"] }
+japanese-address-parser = { version = "0.3.0", features = ["experimental"] }
 napi = { version = "2.16.13", features = ["async"] }
 napi-derive = "2.16.12"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 ToriChan
+Copyright (c) 2024-2026 ToriChan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2026 ToriChan
+Copyright (c) 2024-2026 Yuuki Toriyama
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toriyama/japanese-address-parser-nodejs",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "A Node.js binding for japanese-address-parser written in Rust.",
   "keywords": [
     "utility",


### PR DESCRIPTION
### 変更点
- `japanese-address-parser`のバージョンを0.2.7から0.3.0に更新
- npmjs.comのTrusted Publishingに対応
- ライセンスファイルの更新